### PR TITLE
Added endpoint for getting info for current user

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -14,6 +14,7 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.Handle("/{id}/", alice.New().ThenFunc(GetUserInfo)).Methods("GET")
+	router.Handle("/", alice.New().ThenFunc(GetCurrentUserInfo)).Methods("GET")
 	router.Handle("/", alice.New().ThenFunc(SetUserInfo)).Methods("POST")
 }
 
@@ -22,6 +23,21 @@ func SetupController(route *mux.Route) {
 */
 func GetUserInfo(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+
+	user_info, err := service.GetUserInfo(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(user_info)
+}
+
+/*
+	Endpoint to get the info for the current user
+*/
+func GetCurrentUserInfo(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
 
 	user_info, err := service.GetUserInfo(id)
 

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -143,6 +143,44 @@ func TestGetUserInfoEndpoint(t *testing.T) {
 }
 
 /*
+	End to end test for getting the current user info
+*/
+func TestGetCurrentUserInfoEndpoint(t *testing.T) {
+	SetupTestDB(t)
+
+	req, err := http.NewRequest("GET", "/user/", nil)
+	req.Header.Set("HackIllinois-Identity", "testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res_recorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(controller.GetCurrentUserInfo)
+
+	handler.ServeHTTP(res_recorder, req)
+
+	if res_recorder.Code != http.StatusOK {
+		t.Errorf("Wrong status code. Expected %v Got %v", http.StatusOK, res_recorder.Code)
+	}
+
+	var user_info models.UserInfo
+	json.NewDecoder(res_recorder.Body).Decode(&user_info)
+
+	expected_info := models.UserInfo{
+		ID:       "testid",
+		Username: "testusername",
+		Email:    "testemail@domain.com",
+	}
+
+	if !reflect.DeepEqual(user_info, expected_info) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected_info, user_info)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
 	End to end test for setting user info
 */
 func TestSetUserInfoEndpoint(t *testing.T) {


### PR DESCRIPTION
Addresses #1 

- [x] Add endpoint for getting the currently logged in user

This requires the gateway to decode the user' `id` from their JWT and to place the `id` in the `HackIllinois-Identity` header.